### PR TITLE
generate URI subject

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -19,9 +19,12 @@ import (
 type JWTClaims struct {
 	jwt.RegisteredClaims
 
-	Name  string   `json:"sub_name"`
-	Scope string   `json:"scope"`
-	Units []string `json:"units,omitempty"`
+	OriginalSub string `json:"_original_sub"`
+
+	Name            string   `json:"sub_name"`
+	Scope           string   `json:"scope"`
+	AuthorizedParty string   `json:"azp"`
+	Units           []string `json:"units,omitempty"`
 }
 
 // HasScope returns true if the Scope claim contains the named scope.
@@ -169,6 +172,14 @@ func (p *AuthInfoParser) AuthInfoFromHeader(authorization string) (*AuthInfo, er
 		claims.Scope = p.scopePrefix.ReplaceAllLiteralString(claims.Scope, "")
 	}
 
+	sub, err := claimsToSubject(claims)
+	if err != nil {
+		return nil, err
+	}
+
+	claims.OriginalSub = claims.Subject
+	claims.Subject = sub
+
 	auth := AuthInfo{
 		Claims: claims,
 	}
@@ -178,6 +189,32 @@ func (p *AuthInfoParser) AuthInfoFromHeader(authorization string) (*AuthInfo, er
 	}
 
 	return &auth, nil
+}
+
+var (
+	appURI  = url.URL{Scheme: "core", Host: "application"}
+	userURI = url.URL{Scheme: "core", Host: "user"}
+)
+
+func claimsToSubject(claims JWTClaims) (string, error) {
+	parsedSub, err := url.Parse(claims.Subject)
+	if err != nil {
+		return "", fmt.Errorf("invalid sub claim: %w", err)
+	}
+
+	// This is a fully qualified subject URI, return it as-is.
+	if parsedSub.Scheme != "" {
+		return claims.Subject, nil
+	}
+
+	// This is an application token, return
+	// "core://application/{.AuthorizedParty}".
+	if claims.AuthorizedParty != "" {
+		return appURI.JoinPath(claims.AuthorizedParty).String(), nil
+	}
+
+	// Assume user URI and return "core://user/{.Subject}".
+	return userURI.JoinPath(claims.Subject).String(), nil
 }
 
 // Valid validates the jwt.RegisteredClaims.

--- a/jwt.go
+++ b/jwt.go
@@ -19,7 +19,7 @@ import (
 type JWTClaims struct {
 	jwt.RegisteredClaims
 
-	OriginalSub string `json:"_original_sub"`
+	OriginalSub string `json:"-"`
 
 	Name            string   `json:"sub_name"`
 	Scope           string   `json:"scope"`

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -141,3 +141,52 @@ func TestAuthInfoUnitMapping(t *testing.T) {
 		"core://unit/with-params?id=123#and-hash",
 	}, info.Claims.Units, "get the expected units")
 }
+
+func TestAuthInfoSubjectMapping(t *testing.T) {
+	jwtKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	test.Must(t, err, "create signing key")
+
+	cases := map[string]elephantine.JWTClaims{
+		"core://user/7b328bf3-a53b-4024-a895-c68cb14fdd97": {
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject: "7b328bf3-a53b-4024-a895-c68cb14fdd97",
+			},
+		},
+		"core://user/df1a0b4f-9483-4639-9143-417e876a3405": {
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject: "core://user/df1a0b4f-9483-4639-9143-417e876a3405",
+			},
+		},
+		"core://application/name-of-app": {
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject: "17c11ca5-1eea-4e31-a31c-a0c6e937abd0",
+			},
+			AuthorizedParty: "name-of-app",
+		},
+		"external://sub/of/some/kind": {
+			RegisteredClaims: jwt.RegisteredClaims{
+				Subject: "external://sub/of/some/kind",
+			},
+		},
+	}
+
+	parser := elephantine.NewStaticAuthInfoParser(
+		jwtKey.PublicKey, elephantine.AuthInfoParserOptions{},
+	)
+
+	for want, input := range cases {
+		token := jwt.NewWithClaims(jwt.SigningMethodES384, input)
+
+		ss, err := token.SignedString(jwtKey)
+		test.Must(t, err, "sign JWT token")
+
+		info, err := parser.AuthInfoFromHeader(
+			fmt.Sprintf("Bearer %s", ss))
+		test.Must(t, err, "parse token")
+
+		test.Equal(t, want, info.Claims.Subject,
+			"get the expected sub")
+		test.Equal(t, input.Subject, info.Claims.OriginalSub,
+			"preserve original sub")
+	}
+}


### PR DESCRIPTION
Generate URI subject for schema-less subjects.

* If an "azp" (AuthorizedParty) claim is set, generate an application URI "core://application/{.AuthorizedParty}".
* Otherwise generate a user URI "core://user/{.Subject}".