### PR TITLE
Feature/golden

### DIFF
--- a/test/protobuf.go
+++ b/test/protobuf.go
@@ -192,9 +192,7 @@ func TestMessageAgainstGolden(
 	var cmpOpts cmp.Options
 
 	for _, h := range helpers {
-		for _, opt := range h.CmpOpts() {
-			cmpOpts = append(cmpOpts, opt)
-		}
+		cmpOpts = append(cmpOpts, h.CmpOpts()...)
 	}
 
 	EqualMessageWithOptions(t, wantMessage, got, cmpOpts, "must match golden file %q", goldenPath)


### PR DESCRIPTION
Helper for keeping golden files stable by replacing and ignoring timestamps.

breaking: stable timestamps, golden file helpers

This change allows us to keep timestamps stable when regenerating golden
files. This will result in an initial diff as we're now roundtripping the data
to `map[string]any`, so fields will be sorted alphabetically instead of by
declaration order.

Old golden files will still be valid without being generated.

This breaks TestMessageAgainstGolden() by changing the options parameter:

```diff
 func TestMessageAgainstGolden(
 	t *testing.T,
 	regenerate bool,
 	got proto.Message,
 	goldenPath string,
-	opts ...cmp.Option,
+	helpers ...GoldenHelper,
 ) {
```