### PR TITLE
fix pubsub listener getting stuck on connection errors

### DIFF
--- a/pg/pubsub.go
+++ b/pg/pubsub.go
@@ -123,8 +123,8 @@ func runListener(
 			var notification *pgconn.Notification
 
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-gCtx.Done():
+				return gCtx.Err()
 			case notification = <-received:
 			}
 


### PR DESCRIPTION
The notifier goroutine was checking the wrong context for cancellations, causing the entire wait group to get stuck waiting for the goroutine to exit.