### PR TITLE
add version and BOM endpoints to APIServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,62 @@ Shared functionality for Elephant systems. It's most likely not something anyone
 - `Must`/`MustNot` assertions and generic equality checks with diff output
 - Golden file testing for JSON and protobuf
 - Test helpers for JWT auth, Twirp services, and structured logging
+
+## Reporting the application version
+
+`APIServer` exposes two build-info endpoints:
+
+- `GET /version` on the public API server — JSON summary with the application name, version, VCS stamp, and a curated module list (defaults: `github.com/ttab/elephantine`, `github.com/ttab/elephant-api`, `github.com/ttab/elephant-tt-api`). Pass `APIServerModules(...)` to report additional modules.
+- `GET /debug/bom` on the health/metrics server — the full `debug.BuildInfo` in the canonical `go version -m` format, for SBOM/forensic use. The health server must stay internal.
+
+### Setting the application version
+
+Our services are built as Docker images triggered by git tags. Wire the tag through the pipeline in three places.
+
+**1. Service `main` package** — declare a package-level `version` variable and pass it to `NewAPIServer`:
+
+```go
+package main
+
+var version string // set via -ldflags at build time
+
+func main() {
+    // ...
+    srv := elephantine.NewAPIServer(logger, addr, profileAddr,
+        elephantine.APIServerVersion(version),
+    )
+}
+```
+
+**2. `Dockerfile`** — accept a `VERSION` build-arg and pass it to `go build` via `-ldflags`:
+
+```dockerfile
+ARG TARGETOS TARGETARCH
+ARG VERSION=v0.0.0-dev
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build \
+      -ldflags "-X main.version=$VERSION" \
+      -o /build/myservice ./cmd/myservice
+```
+
+**3. `.github/workflows/build.yaml`** — forward the git tag (`github.ref_name`) to the build-arg:
+
+```yaml
+- name: Build and push release image
+  uses: docker/build-push-action@v7
+  with:
+    context: .
+    platforms: linux/amd64,linux/arm64
+    push: true
+    tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+    build-args: |
+      VERSION=${{ github.ref_name }}
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+The workflow already triggers on `v*` tags, so `github.ref_name` is the tag (`v1.2.3`).
+
+If `APIServerVersion` is not set, or if the binary is built locally without the ldflag, the endpoint reports `v0.0.0-dev`.
+
+VCS revision, timestamp, and dirty state are stamped automatically by the Go toolchain (`-buildvcs=auto`, default) as long as `.git` is present in the build context — which it is with the standard `ADD . ./` step. Dependency versions come from the build graph with no extra flags.

--- a/api_server.go
+++ b/api_server.go
@@ -31,6 +31,25 @@ func APIServerTLS(addr string, certFile string, keyFile string) APIServerOption 
 	}
 }
 
+// APIServerVersion sets the application version string reported by the
+// /version endpoint. If not provided, the version falls back to
+// debug.BuildInfo.Main.Version (which is "(devel)" for plain `go build`).
+func APIServerVersion(version string) APIServerOption {
+	return func(s *APIServer) {
+		s.appVersion = version
+	}
+}
+
+// APIServerModules adds module paths to the /version endpoint's module list.
+// The defaults (github.com/ttab/elephantine, github.com/ttab/elephant-api,
+// github.com/ttab/elephant-tt-api) are always included; modules passed here
+// are appended.
+func APIServerModules(modules ...string) APIServerOption {
+	return func(s *APIServer) {
+		s.modules = append(s.modules, modules...)
+	}
+}
+
 func NewAPIServer(
 	logger *slog.Logger,
 	addr string, profileAddr string,
@@ -124,6 +143,11 @@ func newAPIServer(
 		_, _ = fmt.Fprintln(w, "I AM ALIVE!")
 	}))
 
+	s.Mux.Handle("GET /version", versionHandler(buildBuildInfo(
+		s.appVersion,
+		append(append([]string{}, defaultVersionModules...), s.modules...),
+	)))
+
 	s.Health.AddReadyFunction("api_liveness",
 		LivenessReadyCheck(s.AliveEndpoint()))
 
@@ -140,6 +164,9 @@ type APIServer struct {
 	certFile    string
 	keyFile     string
 	handler     *handlerWrapper
+
+	appVersion string
+	modules    []string
 
 	Mux    *http.ServeMux
 	Health *HealthServer

--- a/health.go
+++ b/health.go
@@ -96,6 +96,7 @@ func (s *HealthServer) setUpMux() *http.ServeMux {
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	mux.Handle("/debug/vars", expvar.Handler())
+	mux.Handle("/debug/bom", http.HandlerFunc(bomHandler))
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/health/ready", http.HandlerFunc(s.readyHandler))
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,156 @@
+package elephantine
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime/debug"
+)
+
+// BuildInfo is the payload returned by the /version endpoint.
+type BuildInfo struct {
+	Application ApplicationInfo   `json:"application"`
+	Modules     map[string]string `json:"modules"`
+}
+
+// ApplicationInfo describes the running application binary.
+type ApplicationInfo struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	VCSRevision string `json:"vcs_revision,omitempty"`
+	VCSTime     string `json:"vcs_time,omitempty"`
+	VCSModified bool   `json:"vcs_modified,omitempty"`
+}
+
+const (
+	unknownVersion = "unknown"
+	// devVersion is reported when neither the application nor the Go
+	// toolchain has stamped a real version into the binary.
+	devVersion = "v0.0.0-dev"
+)
+
+// defaultVersionModules is the baseline set of modules whose versions are
+// reported by /version. APIServerModules appends to this list.
+var defaultVersionModules = []string{
+	"github.com/ttab/elephantine",
+	"github.com/ttab/elephant-api",
+	"github.com/ttab/elephant-tt-api",
+}
+
+func buildBuildInfo(appVersion string, modules []string) BuildInfo {
+	out := BuildInfo{
+		Modules: make(map[string]string, len(modules)),
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		out.Application.Version = resolveAppVersion(appVersion, "")
+
+		for _, m := range modules {
+			if _, exists := out.Modules[m]; exists {
+				continue
+			}
+
+			out.Modules[m] = unknownVersion
+		}
+
+		return out
+	}
+
+	out.Application.Name = info.Main.Path
+	out.Application.Version = resolveAppVersion(appVersion, info.Main.Version)
+
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			out.Application.VCSRevision = s.Value
+		case "vcs.time":
+			out.Application.VCSTime = s.Value
+		case "vcs.modified":
+			out.Application.VCSModified = s.Value == "true"
+		}
+	}
+
+	depVersions := make(map[string]string, len(info.Deps))
+	for _, dep := range info.Deps {
+		depVersions[dep.Path] = dep.Version
+	}
+
+	for _, m := range modules {
+		if _, exists := out.Modules[m]; exists {
+			continue
+		}
+
+		if m == info.Main.Path {
+			out.Modules[m] = out.Application.Version
+
+			continue
+		}
+
+		v, ok := depVersions[m]
+		if !ok {
+			out.Modules[m] = unknownVersion
+
+			continue
+		}
+
+		out.Modules[m] = v
+	}
+
+	return out
+}
+
+// resolveAppVersion picks the application version to report. An explicit
+// value from APIServerVersion wins; otherwise Main.Version is used when it
+// looks like a real module version; otherwise we fall back to devVersion so
+// the field always carries a meaningful string.
+func resolveAppVersion(explicit string, mainVersion string) string {
+	if explicit != "" {
+		return explicit
+	}
+
+	if mainVersion != "" && mainVersion != "(devel)" {
+		return mainVersion
+	}
+
+	return devVersion
+}
+
+func versionHandler(info BuildInfo) http.Handler {
+	body, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		// Should be impossible — BuildInfo is pure strings. Fall back to a
+		// handler that reports the error so the problem is visible.
+		msg := fmt.Sprintf("marshal build info: %v", err)
+
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, msg, http.StatusInternalServerError)
+		})
+	}
+
+	body = append(body, '\n')
+
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		_, _ = w.Write(body)
+	})
+}
+
+// bomHandler writes the full debug.BuildInfo as plain text in the canonical
+// `go version -m` format. Intended to be served on the internal health
+// server only.
+func bomHandler(w http.ResponseWriter, _ *http.Request) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		http.Error(w, "build info not available", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+
+	_, _ = fmt.Fprint(w, info.String())
+}

--- a/version.go
+++ b/version.go
@@ -22,12 +22,9 @@ type ApplicationInfo struct {
 	VCSModified bool   `json:"vcs_modified,omitempty"`
 }
 
-const (
-	unknownVersion = "unknown"
-	// devVersion is reported when neither the application nor the Go
-	// toolchain has stamped a real version into the binary.
-	devVersion = "v0.0.0-dev"
-)
+// devVersion is reported when neither the application nor the Go toolchain
+// has stamped a real version into the binary.
+const devVersion = "v0.0.0-dev"
 
 // defaultVersionModules is the baseline set of modules whose versions are
 // reported by /version. APIServerModules appends to this list.
@@ -45,14 +42,6 @@ func buildBuildInfo(appVersion string, modules []string) BuildInfo {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		out.Application.Version = resolveAppVersion(appVersion, "")
-
-		for _, m := range modules {
-			if _, exists := out.Modules[m]; exists {
-				continue
-			}
-
-			out.Modules[m] = unknownVersion
-		}
 
 		return out
 	}
@@ -89,8 +78,8 @@ func buildBuildInfo(appVersion string, modules []string) BuildInfo {
 
 		v, ok := depVersions[m]
 		if !ok {
-			out.Modules[m] = unknownVersion
-
+			// Module isn't part of this build; skip it rather than
+			// reporting a fake "unknown" version.
 			continue
 		}
 

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,126 @@
+package elephantine_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ttab/elephantine"
+	"github.com/ttab/elephantine/test"
+)
+
+func fetch(t *testing.T, client *http.Client, url string) (*http.Response, []byte) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, url, nil,
+	)
+	test.Must(t, err, "build request for %s", url)
+
+	res, err := client.Do(req)
+	test.Must(t, err, "GET %s", url)
+
+	body, err := io.ReadAll(res.Body)
+	test.Must(t, err, "read body from %s", url)
+
+	err = res.Body.Close()
+	test.Must(t, err, "close body from %s", url)
+
+	return res, body
+}
+
+func TestAPIServerVersionEndpoint(t *testing.T) {
+	logger := slog.New(test.NewLogHandler(t, slog.LevelDebug))
+
+	srv, client := elephantine.NewTestAPIServer(t, logger,
+		elephantine.APIServerVersion("v0.0.0-test"),
+		elephantine.APIServerModules("github.com/prometheus/client_golang"),
+	)
+
+	err := srv.ListenAndServe(context.Background())
+	test.Must(t, err, "start test API server")
+
+	res, body := fetch(t, client, "http://"+srv.Addr()+"/version")
+
+	test.Equal(t, http.StatusOK, res.StatusCode,
+		"status for GET /version")
+	test.Equal(t, "application/json", res.Header.Get("Content-Type"),
+		"content type for GET /version")
+
+	var info elephantine.BuildInfo
+
+	err = json.Unmarshal(body, &info)
+	test.Must(t, err, "decode BuildInfo")
+
+	test.Equal(t, "v0.0.0-test", info.Application.Version,
+		"application version reflects APIServerVersion")
+
+	if info.Application.Name == "" {
+		t.Fatal("expected non-empty application name")
+	}
+
+	// Default modules are always reported. elephantine is the test's own
+	// module so its entry reflects Main.Version (via APIServerVersion here).
+	test.Equal(t, "v0.0.0-test",
+		info.Modules["github.com/ttab/elephantine"],
+		"elephantine module version tracks the application version")
+
+	for _, m := range []string{
+		"github.com/ttab/elephant-api",
+		"github.com/ttab/elephant-tt-api",
+		"github.com/prometheus/client_golang",
+	} {
+		if _, ok := info.Modules[m]; !ok {
+			t.Errorf("expected module %q in response", m)
+		}
+	}
+}
+
+func TestAPIServerVersionEndpointDefault(t *testing.T) {
+	logger := slog.New(test.NewLogHandler(t, slog.LevelDebug))
+
+	srv, client := elephantine.NewTestAPIServer(t, logger)
+
+	err := srv.ListenAndServe(context.Background())
+	test.Must(t, err, "start test API server")
+
+	_, body := fetch(t, client, "http://"+srv.Addr()+"/version")
+
+	var info elephantine.BuildInfo
+
+	err = json.Unmarshal(body, &info)
+	test.Must(t, err, "decode BuildInfo")
+
+	test.Equal(t, "v0.0.0-dev", info.Application.Version,
+		"default application version when APIServerVersion is not set")
+}
+
+func TestHealthServerBOMEndpoint(t *testing.T) {
+	logger := slog.New(test.NewLogHandler(t, slog.LevelDebug))
+
+	srv, _ := elephantine.NewTestAPIServer(t, logger)
+
+	err := srv.ListenAndServe(context.Background())
+	test.Must(t, err, "start test API server")
+
+	res, body := fetch(t, http.DefaultClient,
+		"http://"+srv.Health.Addr()+"/debug/bom")
+
+	test.Equal(t, http.StatusOK, res.StatusCode,
+		"status for GET /debug/bom")
+
+	ct := res.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("expected text/plain content type, got %q", ct)
+	}
+
+	// Under `go test`, debug.BuildInfo.Deps is empty, so we can't rely on a
+	// "dep\t" line. The main module line is always present.
+	if !strings.Contains(string(body), "mod\tgithub.com/ttab/elephantine") {
+		t.Error("expected BOM to list the main module line")
+	}
+}

--- a/version_test.go
+++ b/version_test.go
@@ -63,19 +63,21 @@ func TestAPIServerVersionEndpoint(t *testing.T) {
 		t.Fatal("expected non-empty application name")
 	}
 
-	// Default modules are always reported. elephantine is the test's own
-	// module so its entry reflects Main.Version (via APIServerVersion here).
+	// elephantine is the test's own module, so its entry is reported via
+	// Main.Version (overridden here by APIServerVersion).
 	test.Equal(t, "v0.0.0-test",
 		info.Modules["github.com/ttab/elephantine"],
 		"elephantine module version tracks the application version")
 
+	// Under `go test` debug.BuildInfo.Deps is empty, so modules that aren't
+	// part of the build are skipped rather than reported as "unknown".
 	for _, m := range []string{
 		"github.com/ttab/elephant-api",
 		"github.com/ttab/elephant-tt-api",
 		"github.com/prometheus/client_golang",
 	} {
-		if _, ok := info.Modules[m]; !ok {
-			t.Errorf("expected module %q in response", m)
+		if v, ok := info.Modules[m]; ok {
+			t.Errorf("module %q unexpectedly present: %q", m, v)
 		}
 	}
 }


### PR DESCRIPTION
Services currently have no runtime way to answer "what version am I running, and against which libraries was I built". This adds two endpoints to the shared APIServer:

- GET /version on the public API port — JSON summary with the application name, version, VCS stamp, and a curated module list (elephantine, elephant-api, elephant-tt-api by default).
- GET /debug/bom on the internal health/metrics port — full debug.BuildInfo in the canonical `go version -m` format for SBOM and forensic use.

## Configuration

Two new functional options on NewAPIServer:

- APIServerVersion(version) — set the application version string, typically fed from `-ldflags "-X main.version=..."` at build time.
- APIServerModules(modules...) — append additional module paths to the /version module list; the defaults stay in place.

If no version is provided and the binary carries no module version (the usual case for `go build`), /version reports v0.0.0-dev.

## Build integration

README documents the full tag → Docker build-arg → ldflag pipeline matching our existing github-workflow + Dockerfile setup: the workflow forwards github.ref_name as a VERSION build-arg, the Dockerfile passes it into `-ldflags -X main.version=$VERSION`, and the service main declares `var version string`. VCS revision/time/ modified are stamped automatically by the Go toolchain as long as .git is in the build context (which it is with `ADD . ./`).