### PR TITLE
add FanOut recovery: Subscriber.Bounce and consecutive-poll tracking

### DIFF
--- a/docs/fanout-recovery.md
+++ b/docs/fanout-recovery.md
@@ -1,0 +1,215 @@
+# FanOut recovery
+
+The `pg.Subscriber` + `pg.FanOut[T]` pair gives a process a single LISTEN
+connection that distributes Postgres notifications to multiple in-process
+consumers. The `Subscriber` already detects a silently dead listen
+connection via periodic pings (see `WithPingInterval` / `WithPingGrace`),
+but the ping path can stay healthy while application notifications stop
+flowing — for example after a PgBouncer reset that swallowed the LISTEN
+re-issue, or when a deploy script restarted only one side of the
+publish/subscribe pair.
+
+`FanOut.EnableRecovery` + `Subscriber.Bounce` close that gap. A consumer
+that combines a real-time notification path with a slower fallback poll
+can observe when polling is the only thing keeping it caught up, surface
+that state to operators as a Prometheus metric, and have the FanOut force
+the `Subscriber` to tear down its LISTEN connection and reconnect once
+the divergence crosses a threshold.
+
+## The signal
+
+A consumer of a FanOut typically has two ways to learn about new work:
+
+1. A wire-side notification arrives via the FanOut. The FanOut delivers
+   it to listeners. The consumer drains its underlying state.
+2. A periodic fallback poll runs (every few seconds) and queries the
+   underlying state directly. If it finds work, the LISTEN path failed to
+   deliver — or the publisher hasn't fired NOTIFY yet.
+
+Under normal conditions notifications race ahead of the poll: polls find
+nothing, the FanOut delivers each event, and the consumer drains via the
+notification path. When notifications stop flowing while writes continue,
+the poll starts finding work consistently. That state — "polls keeping
+the consumer afloat without notifications" — is the symptom of a broken
+subscription, and is what the recovery wiring measures.
+
+> A single poll discovering work just before a notification arrives is
+> normal racing, not a fault. The threshold absorbs that background
+> noise.
+
+## How it works
+
+The FanOut owns the recovery state once `EnableRecovery` has been called:
+
+- **`FanOut.Polled(found int)`** is the consumer-facing report. Call it
+  after each fallback-poll iteration with the number of items the
+  iteration found. A `found == 0` call is a no-op; the FanOut only cares
+  whether each call did or did not find work.
+- **The streak counts calls, not items.** Each non-empty poll advances
+  the streak by exactly one, no matter how much backlog it cleared.
+  This way a busy publisher whose single mistimed poll catches up 1000
+  items does not trip the bounce — the threshold only fires when polls
+  *keep* finding work without notifications in between.
+- **The wire-side reset is automatic.** Whenever `FanOut.NotifyWithPayload`
+  dispatches a real PG NOTIFY to listeners, it resets the streak. The
+  consumer does not need to do anything to participate.
+- **`Subscriber.Bounce`** is the back-channel. Once the consecutive
+  non-empty poll count crosses the threshold (default 5), the FanOut
+  calls the bounce callback you supplied — typically `subscriber.Bounce`
+  — and resets the streak so the next round of measurements starts from
+  zero against the freshly reconnected listener.
+
+A single `Subscriber` can be shared by many FanOuts; each FanOut decides
+independently when to bounce. Multiple bounces during a single outage
+coalesce — `Subscriber.Bounce` is a non-blocking send on a buffered
+channel, and the listen loop drains any pending signal at the start of
+each fresh connection.
+
+### Metrics
+
+`EnableRecovery` registers two metrics through an
+`elephantine.MetricsHelper`:
+
+- `pg_fanout_<channel>_poll_saved_total` (counter) — every item that
+  arrived via the fallback poll. Useful for long-term graphing of
+  notification dropouts; counted per item so a single fat drain shows
+  its true volume.
+- `pg_fanout_<channel>_poll_saved_streak` (gauge) — the number of
+  *consecutive non-empty fallback-poll calls* since the last wire-side
+  notification. One backlog-clearing poll counts as one, regardless of
+  how many items it drained. Resets to 0 on each successful delivery
+  from the LISTEN connection or after a bounce.
+
+The channel name is sanitized to a Prometheus-safe segment (characters
+outside `[a-zA-Z0-9_]` become `_`).
+
+The streak gauge is the right thing to alert on. Example PromQL:
+
+```
+pg_fanout_outbox_new_poll_saved_streak > 0
+```
+
+Hold for a few minutes to avoid flapping. The counter is for capacity
+planning ("how often is this happening overall?") and post-incident
+analysis.
+
+## Wiring it up
+
+A consumer that wants the recovery pattern needs:
+
+1. A FanOut for the notification channel.
+2. A `Subscriber` (typically shared across all FanOuts in the process).
+3. A `MetricsHelper` so the FanOut can register its metrics.
+4. A poll loop with a fallback period (e.g. 5 seconds).
+
+```go
+const ChannelName = "outbox_new"
+
+type Notification struct {
+    BlogID uuid.UUID `json:"blog_id"`
+}
+
+// FanOut, Subscriber, recovery wiring. The Subscriber takes the FanOut as
+// a ChannelSubscription; then we hand the Subscriber's Bounce back to the
+// FanOut so the recovery loop closes.
+fanout := pg.NewFanOut[Notification](ChannelName)
+sub := pg.NewSubscriber(logger, pool, []pg.ChannelSubscription{fanout})
+
+err := fanout.EnableRecovery(
+    elephantine.NewMetricsHelper(registerer),
+    sub.Bounce,
+    // pg.WithBounceThreshold(5) is the default.
+)
+if err != nil {
+    return fmt.Errorf("enable fanout recovery: %w", err)
+}
+
+// Consumer side: a small wakeup channel registered with the FanOut, plus
+// a fallback poll ticker. The consumer reports poll findings via
+// fanout.Polled; the wire-side reset happens automatically inside the
+// FanOut.
+events := make(chan Notification, 64)
+
+go fanout.ListenAll(ctx, events)
+go sub.Run(ctx)
+
+ticker := time.NewTicker(5 * time.Second)
+defer ticker.Stop()
+
+_ = drain() // initial backlog catch-up on startup
+
+for {
+    select {
+    case <-ctx.Done():
+        return
+    case <-ticker.C:
+        n, err := drain()
+        if err != nil {
+            logger.Error("poll drain", "err", err)
+            continue
+        }
+        fanout.Polled(n)
+    case <-events:
+        _, _ = drain()
+        // No Notified call needed — the FanOut already reset the streak
+        // when NotifyWithPayload dispatched this notification to us.
+    }
+}
+```
+
+### Channel buffer sizing
+
+The FanOut listener's channel buffer (`events` above) needs to hold
+exactly one pending wake-up. A "wake up and drain" consumer pulls all
+available work on every wake-up, so it does not matter whether one or
+one thousand wire notifications fired while the drain was in flight —
+the next wake-up catches up the entire backlog. **Use a buffer of 1.**
+
+The recovery streak is unaffected by listener drops. `NotifyWithPayload`
+resets the streak as soon as it dispatches the message via `Notify`;
+with the default `OverflowDrop` policy the dispatch returns nil even
+when no listener had room to queue the message, and the reset still
+fires. Drops at the listener therefore measure consumer throughput, not
+wire health.
+
+`FanOut` with the default `OverflowDrop` policy silently drops a
+notification when the listener channel is full. That is the right
+choice for a "wake up and drain" consumer — the payload is just a kick,
+the actual work is whatever the drain finds.
+
+### Publisher side
+
+The publisher calls `fanout.Publish(ctx, db, payload)` after committing
+the underlying write. `pg_notify` only fires at commit anyway; publishing
+*after* the commit return keeps the publisher cheap and the consumer
+behaviour predictable. A publish failure is tolerable because the
+consumer's fallback poll will catch the orphaned write — log the error
+and move on.
+
+### `OnReconnect`
+
+`Subscriber.WithOnReconnect` is called before each LISTEN is re-issued,
+including after a bounce. Use it to nudge consumers that a reconnect
+happened so they can poll-drain immediately rather than waiting for the
+next tick. Keep the callback short — it runs synchronously inside the
+listen loop and delays the next `LISTEN`.
+
+## Tuning
+
+| Knob | Default | When to change |
+| ---- | ------- | -------------- |
+| `WithBounceThreshold` | 5 | Lower for very latency-sensitive consumers (fires faster but more aggressively on transient blips). Higher for systems where publishers sometimes fall behind their writes, so racing polls can rack up the streak in normal operation. |
+| Fallback poll period | consumer-defined (e.g. 5 s) | Shorter polls catch up faster after a missed notification but raise the rate at which a sick LISTEN can grow the streak — combined with `WithBounceThreshold`, this controls the time-to-bounce (≈ `threshold × poll_period` in the worst case). |
+| `WithPingInterval` / `WithPingGrace` | 5 min / 7 min | Lower for connections that fail silently on shorter timescales (aggressive NAT/load balancer idle timeouts). |
+
+## What this isn't
+
+- It does not replace the ping-based health check. The ping detects fully
+  dead connections; the recovery wiring detects "alive but not
+  delivering."
+- It does not retry individual notifications. A dropped notification is
+  always recovered by the fallback poll, with at most one poll-period
+  worth of latency.
+- It does not coordinate across replicas. Each replica's FanOut bounces
+  its own `Subscriber`. That is correct: a connection is bad or good per
+  replica, not globally.

--- a/pg/pubsub.go
+++ b/pg/pubsub.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/ttab/elephantine"
 	"golang.org/x/sync/errgroup"
 )
@@ -21,7 +22,10 @@ import (
 // received notifications to verify that the LISTEN connection is still alive.
 const PingChannel = "listener_ping"
 
-var errPingTimeout = errors.New("listener ping timeout")
+var (
+	errPingTimeout = errors.New("listener ping timeout")
+	errBounce      = errors.New("listener bounce requested")
+)
 
 // SubscriberOption configures a Subscriber.
 type SubscriberOption func(*Subscriber)
@@ -77,6 +81,12 @@ type Subscriber struct {
 	pingGrace    time.Duration
 	channels     []ChannelSubscription
 	onReconnect  func(ctx context.Context) error
+	// bounceCh receives requests to tear down the current LISTEN connection
+	// and reconnect. Buffered to depth 1 so multiple concurrent Bounce calls
+	// coalesce into one pending signal; runListenerWithPing drains it on
+	// entry so signals queued during a previous outage don't immediately
+	// trip the fresh connection.
+	bounceCh chan struct{}
 }
 
 // NewSubscriber creates a new Subscriber that listens on the given channels. By
@@ -94,6 +104,7 @@ func NewSubscriber(
 		pingInterval: 5 * time.Minute,
 		pingGrace:    7 * time.Minute,
 		channels:     channels,
+		bounceCh:     make(chan struct{}, 1),
 	}
 
 	for _, opt := range opts {
@@ -101,6 +112,24 @@ func NewSubscriber(
 	}
 
 	return s
+}
+
+// Bounce signals the listen loop to tear down the current PostgreSQL LISTEN
+// connection and reconnect on the next iteration. The call is non-blocking;
+// concurrent Bounce invocations coalesce into a single pending signal, and the
+// listen loop drains any pending signal at the start of each connection so a
+// signal queued during a previous outage does not immediately tear down a
+// fresh connection.
+//
+// Bounce is intended for forcing a reconnect when an external signal (e.g. a
+// RecoveryTracker noticing that polling is keeping a consumer afloat without
+// notifications) suggests the LISTEN connection is silently broken even
+// though the ping path appears healthy.
+func (s *Subscriber) Bounce() {
+	select {
+	case s.bounceCh <- struct{}{}:
+	default:
+	}
 }
 
 // SendListenerPing sends a ping notification on the PingChannel. This can be
@@ -174,6 +203,10 @@ func (s *Subscriber) runListenLoop(ctx context.Context) error {
 			s.logger.WarnContext(ctx,
 				"listener ping timeout, reconnecting",
 			)
+		case errors.Is(err, errBounce):
+			s.logger.WarnContext(ctx,
+				"listener bounce requested, reconnecting",
+			)
 		case err != nil:
 			return err
 		}
@@ -187,6 +220,16 @@ func (s *Subscriber) runListenLoop(ctx context.Context) error {
 }
 
 func (s *Subscriber) runListenerWithPing(ctx context.Context) (outErr error) {
+	// Drain any stale bounce signal queued during a previous outage so that
+	// the fresh connection we're about to set up is not immediately torn
+	// down. With multiple consumers, several Bounce calls can race during a
+	// single outage; the buffered channel coalesces them and this drain
+	// discards the leftover.
+	select {
+	case <-s.bounceCh:
+	default:
+	}
+
 	if s.onReconnect != nil {
 		err := s.onReconnect(ctx)
 		if err != nil {
@@ -233,18 +276,41 @@ func (s *Subscriber) runListenerWithPing(ctx context.Context) (outErr error) {
 		return fmt.Errorf("start listening to ping channel: %w", err)
 	}
 
+	// bounceCtx is a child of ctx that we cancel as soon as a bounce signal
+	// arrives. The waiter goroutine below watches bounceCh for the lifetime
+	// of this listen attempt; it exits when bounceCtx is done (either
+	// because we bounced, the parent was cancelled, or this function
+	// returned).
+	bounceCtx, cancelBounce := context.WithCancel(ctx)
+	defer cancelBounce()
+
+	go func() {
+		select {
+		case <-s.bounceCh:
+			cancelBounce()
+		case <-bounceCtx.Done():
+		}
+	}()
+
 	lastPing := time.Now()
 
 	for {
 		deadline := lastPing.Add(s.pingGrace)
 
-		waitCtx, waitCancel := context.WithDeadline(ctx, deadline)
+		waitCtx, waitCancel := context.WithDeadline(bounceCtx, deadline)
 
 		notification, err := pConn.WaitForNotification(waitCtx)
 
 		waitCancel()
 
 		if err != nil {
+			// A bounce signal cancels bounceCtx while the parent ctx
+			// is still healthy; surface it so the outer loop can
+			// reconnect.
+			if bounceCtx.Err() != nil && ctx.Err() == nil {
+				return errBounce
+			}
+
 			if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
 				return errPingTimeout
 			}
@@ -446,6 +512,10 @@ type FanOut[T any] struct {
 	overflowPolicy OverflowPolicy
 	m              sync.RWMutex
 	listeners      map[chan T]func(v T) bool
+	// recovery is non-nil once EnableRecovery has been called. Reads and
+	// writes are guarded by m so EnableRecovery is safe to call after
+	// listeners have started, though that is rarely useful.
+	recovery *recoveryTracker
 }
 
 func NewFanOut[T any](channel string, opts ...FanOutOption) *FanOut[T] {
@@ -460,6 +530,88 @@ func NewFanOut[T any](channel string, opts ...FanOutOption) *FanOut[T] {
 		overflowPolicy: cfg.overflowPolicy,
 		listeners:      make(map[chan T]func(v T) bool),
 	}
+}
+
+// EnableRecovery wires this FanOut into the recovery pattern documented in
+// elephantine's docs/fanout-recovery.md: callers report fallback-poll
+// findings via Polled, the FanOut resets the streak whenever it dispatches a
+// wire-side notification (NotifyWithPayload), and bounce is invoked once the
+// poll-saved streak crosses the configured threshold (default 5). Pass
+// Subscriber.Bounce for bounce so the recovery loop closes back onto the
+// listener.
+//
+// EnableRecovery registers a per-channel poll-saved counter and streak gauge
+// through metrics, using the channel name (sanitized) as the metric name
+// suffix. Registration errors are returned and also recorded on the metrics
+// helper.
+//
+// Calling EnableRecovery more than once replaces the previous wiring; that
+// is rarely useful but legal.
+func (f *FanOut[T]) EnableRecovery(
+	metrics *elephantine.MetricsHelper,
+	bounce func(),
+	opts ...FanOutRecoveryOption,
+) error {
+	cfg := fanOutRecoveryConfig{threshold: defaultBounceThreshold}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	suffix := sanitizeMetricSegment(f.channel)
+
+	var (
+		pollCounter prometheus.Counter
+		streakGauge prometheus.Gauge
+	)
+
+	metrics.Counter(&pollCounter, prometheus.CounterOpts{
+		Name: "pg_fanout_" + suffix + "_poll_saved_total",
+		Help: "Items the fallback poll for FanOut channel " + f.channel +
+			" relayed before a notification arrived.",
+	})
+
+	metrics.Gauge(&streakGauge, prometheus.GaugeOpts{
+		Name: "pg_fanout_" + suffix + "_poll_saved_streak",
+		Help: "Consecutive non-empty fallback-poll drains for FanOut " +
+			"channel " + f.channel + " without an intervening " +
+			"notification. Counts calls, not items, so a busy " +
+			"publisher cannot trip the bounce on a single mistimed " +
+			"poll.",
+	})
+
+	err := metrics.Err()
+	if err != nil {
+		return fmt.Errorf("register FanOut recovery metrics: %w", err)
+	}
+
+	tracker := newRecoveryTracker(bounce, cfg.threshold, pollCounter, streakGauge)
+
+	f.m.Lock()
+	f.recovery = tracker
+	f.m.Unlock()
+
+	return nil
+}
+
+// Polled reports that a fallback-poll iteration discovered `found` items of
+// work. With recovery enabled, a call with found > 0 advances the consecutive
+// non-empty-poll streak by one (regardless of how many items were drained,
+// so a backlog-clearing poll does not trip the threshold by itself) and adds
+// `found` to the per-item counter. Once the streak crosses the configured
+// threshold the bounce callback fires and the streak resets. With recovery
+// not enabled, Polled is a no-op; consumers may call it unconditionally. A
+// call with found <= 0 is always a no-op.
+func (f *FanOut[T]) Polled(found int) {
+	f.m.RLock()
+	rec := f.recovery
+	f.m.RUnlock()
+
+	if rec == nil {
+		return
+	}
+
+	rec.polled(found)
 }
 
 // ListenAll listens for notifications until the context is cancelled.
@@ -488,7 +640,10 @@ func (f *FanOut[T]) ChannelName() string {
 	return f.channel
 }
 
-// Implements ChannelSubscription.
+// Implements ChannelSubscription. The wire-side delivery path: invoked by the
+// Subscriber when a Postgres NOTIFY arrives on this channel. Successful
+// dispatch resets the recovery streak (if enabled), signalling that the
+// LISTEN connection is healthy.
 func (f *FanOut[T]) NotifyWithPayload(data []byte) error {
 	var e T
 
@@ -500,6 +655,14 @@ func (f *FanOut[T]) NotifyWithPayload(data []byte) error {
 	err = f.Notify(e)
 	if err != nil {
 		return fmt.Errorf("notify listeners: %w", err)
+	}
+
+	f.m.RLock()
+	rec := f.recovery
+	f.m.RUnlock()
+
+	if rec != nil {
+		rec.notified()
 	}
 
 	return nil

--- a/pg/recovery.go
+++ b/pg/recovery.go
@@ -1,0 +1,130 @@
+package pg
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// defaultBounceThreshold is how many consecutive poll-saved findings (without
+// a notification arriving) trigger a Subscriber bounce by default.
+const defaultBounceThreshold = 5
+
+// FanOutRecoveryOption configures the recovery behaviour wired up by
+// FanOut.EnableRecovery.
+type FanOutRecoveryOption func(*fanOutRecoveryConfig)
+
+type fanOutRecoveryConfig struct {
+	threshold int
+}
+
+// WithBounceThreshold sets how many consecutive non-empty fallback-poll
+// drains (calls to FanOut.Polled with found > 0) without an intervening
+// notification trigger a bounce. The count is of *calls*, not items: a
+// single chunky drain that catches up a backlog counts as one, so a busy
+// publisher does not trip the threshold with one mistimed poll. Zero or
+// negative disables the bounce; the metric is still maintained. Defaults
+// to 5.
+func WithBounceThreshold(n int) FanOutRecoveryOption {
+	return func(c *fanOutRecoveryConfig) {
+		c.threshold = n
+	}
+}
+
+// recoveryTracker is the per-FanOut state for the recovery pattern. It is
+// internal to the pg package; consumers interact with it through
+// FanOut.EnableRecovery and FanOut.Polled.
+type recoveryTracker struct {
+	bounce      func()
+	threshold   int
+	pollCounter prometheus.Counter
+	streakGauge prometheus.Gauge
+
+	mu     sync.Mutex
+	streak int
+}
+
+func newRecoveryTracker(
+	bounce func(), threshold int,
+	pollCounter prometheus.Counter, streakGauge prometheus.Gauge,
+) *recoveryTracker {
+	return &recoveryTracker{
+		bounce:      bounce,
+		threshold:   threshold,
+		pollCounter: pollCounter,
+		streakGauge: streakGauge,
+	}
+}
+
+// polled is called by FanOut.Polled when a consumer reports `found` items
+// from a fallback-poll iteration. The streak counts non-empty *calls*, not
+// items: each non-empty drain adds 1, regardless of how much backlog the
+// drain caught up. The per-item counter still tallies items, since that
+// remains useful as a long-term volume signal.
+func (t *recoveryTracker) polled(found int) {
+	if found <= 0 {
+		return
+	}
+
+	t.mu.Lock()
+
+	t.streak++
+	streak := t.streak
+
+	bounce := t.threshold > 0 && streak >= t.threshold
+	if bounce {
+		t.streak = 0
+	}
+
+	t.mu.Unlock()
+
+	if t.pollCounter != nil {
+		t.pollCounter.Add(float64(found))
+	}
+
+	if t.streakGauge != nil {
+		if bounce {
+			t.streakGauge.Set(0)
+		} else {
+			t.streakGauge.Set(float64(streak))
+		}
+	}
+
+	if bounce {
+		t.bounce()
+	}
+}
+
+// notified is called by FanOut.NotifyWithPayload when a real wire-side
+// notification has been received and dispatched.
+func (t *recoveryTracker) notified() {
+	t.mu.Lock()
+	had := t.streak > 0
+	t.streak = 0
+	t.mu.Unlock()
+
+	if had && t.streakGauge != nil {
+		t.streakGauge.Set(0)
+	}
+}
+
+// sanitizeMetricSegment converts a channel name into a Prometheus-name-safe
+// segment by replacing any character outside [a-zA-Z0-9_] with '_'.
+func sanitizeMetricSegment(s string) string {
+	out := make([]byte, 0, len(s))
+
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '_':
+			out = append(out, c)
+		default:
+			out = append(out, '_')
+		}
+	}
+
+	return string(out)
+}

--- a/pg/recovery_test.go
+++ b/pg/recovery_test.go
@@ -1,0 +1,185 @@
+package pg_test
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/ttab/elephantine"
+	"github.com/ttab/elephantine/pg"
+)
+
+func TestFanOutRecoveryBouncesAtThreshold(t *testing.T) {
+	var bounced atomic.Int32
+
+	reg := prometheus.NewRegistry()
+	fo := pg.NewFanOut[string]("test_channel")
+
+	err := fo.EnableRecovery(
+		elephantine.NewMetricsHelper(reg),
+		func() { bounced.Add(1) },
+		pg.WithBounceThreshold(3),
+	)
+	if err != nil {
+		t.Fatalf("EnableRecovery: %v", err)
+	}
+
+	fo.Polled(1)
+	fo.Polled(1)
+
+	if got := bounced.Load(); got != 0 {
+		t.Fatalf("expected no bounce before threshold, got %d", got)
+	}
+
+	fo.Polled(1)
+
+	if got := bounced.Load(); got != 1 {
+		t.Fatalf("expected one bounce at threshold, got %d", got)
+	}
+
+	// Streak resets after bouncing.
+	fo.Polled(1)
+
+	if got := bounced.Load(); got != 1 {
+		t.Fatalf("expected streak to reset after bounce, got %d bounces", got)
+	}
+}
+
+func TestFanOutRecoveryResetsOnWireNotification(t *testing.T) {
+	var bounced atomic.Int32
+
+	reg := prometheus.NewRegistry()
+	fo := pg.NewFanOut[string]("test_channel")
+
+	err := fo.EnableRecovery(
+		elephantine.NewMetricsHelper(reg),
+		func() { bounced.Add(1) },
+		pg.WithBounceThreshold(3),
+	)
+	if err != nil {
+		t.Fatalf("EnableRecovery: %v", err)
+	}
+
+	fo.Polled(1)
+	fo.Polled(1)
+
+	// Simulate a wire-side delivery (the Subscriber would call this on
+	// each PG NOTIFY).
+	err = fo.NotifyWithPayload([]byte(`"hello"`))
+	if err != nil {
+		t.Fatalf("NotifyWithPayload: %v", err)
+	}
+
+	fo.Polled(1)
+	fo.Polled(1)
+
+	if got := bounced.Load(); got != 0 {
+		t.Fatalf("expected no bounce after wire reset, got %d", got)
+	}
+}
+
+func TestFanOutRecoveryDirectNotifyDoesNotReset(t *testing.T) {
+	var bounced atomic.Int32
+
+	reg := prometheus.NewRegistry()
+	fo := pg.NewFanOut[string]("test_channel")
+
+	err := fo.EnableRecovery(
+		elephantine.NewMetricsHelper(reg),
+		func() { bounced.Add(1) },
+		pg.WithBounceThreshold(2),
+	)
+	if err != nil {
+		t.Fatalf("EnableRecovery: %v", err)
+	}
+
+	fo.Polled(1)
+
+	// A direct in-process Notify is not a wire signal and must not reset
+	// the recovery streak. The next Polled should trip the threshold.
+	err = fo.Notify("synthetic")
+	if err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+
+	fo.Polled(1)
+
+	if got := bounced.Load(); got != 1 {
+		t.Fatalf("expected bounce despite intervening direct Notify, got %d", got)
+	}
+}
+
+func TestFanOutRecoveryStreakCountsCallsNotItems(t *testing.T) {
+	var bounced atomic.Int32
+
+	reg := prometheus.NewRegistry()
+	fo := pg.NewFanOut[string]("test_channel")
+
+	err := fo.EnableRecovery(
+		elephantine.NewMetricsHelper(reg),
+		func() { bounced.Add(1) },
+		pg.WithBounceThreshold(3),
+	)
+	if err != nil {
+		t.Fatalf("EnableRecovery: %v", err)
+	}
+
+	// A single fat backlog drain must not trip the threshold; only
+	// consecutive non-empty calls count, not items.
+	fo.Polled(1000)
+
+	if got := bounced.Load(); got != 0 {
+		t.Fatalf("expected no bounce from a single chunky drain, got %d", got)
+	}
+
+	fo.Polled(1)
+
+	if got := bounced.Load(); got != 0 {
+		t.Fatalf("expected no bounce at 2 consecutive drains, got %d", got)
+	}
+
+	fo.Polled(1)
+
+	if got := bounced.Load(); got != 1 {
+		t.Fatalf("expected bounce at 3 consecutive drains, got %d", got)
+	}
+}
+
+func TestFanOutPolledNoopWithoutRecovery(t *testing.T) {
+	fo := pg.NewFanOut[string]("test_channel")
+	// Must not panic or count anything when EnableRecovery has not been
+	// called; consumers may call Polled unconditionally.
+	fo.Polled(5)
+}
+
+func TestFanOutRecoveryRegistersMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	fo := pg.NewFanOut[string]("outbox.new") // exercise sanitization
+
+	err := fo.EnableRecovery(
+		elephantine.NewMetricsHelper(reg),
+		func() {},
+	)
+	if err != nil {
+		t.Fatalf("EnableRecovery: %v", err)
+	}
+
+	gathered, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, mf := range gathered {
+		names[mf.GetName()] = true
+	}
+
+	for _, want := range []string{
+		"pg_fanout_outbox_new_poll_saved_total",
+		"pg_fanout_outbox_new_poll_saved_streak",
+	} {
+		if !names[want] {
+			t.Fatalf("expected metric %q registered, got %v", want, names)
+		}
+	}
+}


### PR DESCRIPTION
When a Postgres LISTEN connection goes silently bad — PgBouncer eating the LISTEN re-issue, a network partition that survives the keepalive, etc. — the existing ping-based health check stays green while application notifications stop flowing. Consumers paper over the gap with a fallback poll but have no way to flag that polling is the only thing keeping them caught up, and no way to force a reconnect short of restarting the process.

Subscriber.Bounce signals the listen loop to tear down the current connection and reconnect on the next iteration. The channel is buffered to depth 1 so multiple consumers' bounces during one outage coalesce, and the loop drains any pending signal at the start of each fresh connection so stale bounces don't immediately tear down a healthy reconnect.

FanOut.EnableRecovery folds the recovery bookkeeping into the FanOut itself: consumers report fallback-poll findings via FanOut.Polled, the FanOut auto-resets the streak inside NotifyWithPayload on each wire-side delivery, and the FanOut bounces the Subscriber once the streak crosses a configurable threshold. The streak counts consecutive non-empty *calls*, not items, so a single backlog-clearing poll on a busy pipeline does not trip the bounce. EnableRecovery registers per- channel poll-saved counter and streak gauge metrics through a MetricsHelper.

See docs/fanout-recovery.md for the full pattern and example wiring.