### PR TITLE
add ErrGroup.Required for tasks that must stop the group on exit

### DIFF
--- a/errgroup.go
+++ b/errgroup.go
@@ -2,12 +2,21 @@ package elephantine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"golang.org/x/sync/errgroup"
 )
+
+// ErrTaskDisabled can be returned by a Required task to signal that it is
+// disabled (typically by configuration) and should not run. The group treats
+// it as if the task was never registered: it does not cancel the group, and
+// Wait does not report it as an error. This lets callers register a task
+// unconditionally and opt out from inside it, instead of wrapping the
+// registration in a conditional.
+var ErrTaskDisabled = errors.New("task disabled")
 
 type BackoffFunction func(retry int) time.Duration
 
@@ -65,6 +74,10 @@ func (eg *ErrGroup) Go(task string, fn func(ctx context.Context) error) {
 // restarted, rather than linger with only a subset of its subsystems running.
 // A nil return still yields a nil Wait result unless a sibling reports an
 // error, so a clean shutdown stays clean.
+//
+// A task that is disabled by configuration can return ErrTaskDisabled to opt
+// out: the group is then left untouched, as if the task had never been
+// registered.
 func (eg *ErrGroup) Required(task string, fn func(ctx context.Context) error) {
 	eg.grp.Go(func() error {
 		eg.logger.Info("starting task",
@@ -73,13 +86,23 @@ func (eg *ErrGroup) Required(task string, fn func(ctx context.Context) error) {
 		defer eg.logger.Info("stopped task",
 			LogKeyName, task)
 
-		// The group can't continue without this task, so cancel the
-		// group context when it returns regardless of whether it
-		// failed. This stops the sibling tasks instead of leaving
-		// them running without a subsystem they depend on.
-		defer eg.cancel()
-
 		err := CallWithRecover(eg.gCtx, fn)
+
+		// A disabled task opted out of running, so leave the rest of
+		// the group alone — it's as if the task was never registered.
+		if errors.Is(err, ErrTaskDisabled) {
+			eg.logger.Info("task disabled",
+				LogKeyName, task)
+
+			return nil
+		}
+
+		// The group can't continue without this task, so cancel the
+		// group context now that it has returned, regardless of
+		// whether it failed. This stops the sibling tasks instead of
+		// leaving them running without a subsystem they depend on.
+		eg.cancel()
+
 		if err != nil {
 			return fmt.Errorf("%s: %w", task, err)
 		}

--- a/errgroup.go
+++ b/errgroup.go
@@ -12,12 +12,19 @@ import (
 type BackoffFunction func(retry int) time.Duration
 
 func NewErrGroup(ctx context.Context, logger *slog.Logger) *ErrGroup {
+	// Derive our own cancellation before handing the context to the
+	// errgroup, so that the group context tasks observe is cancelled both
+	// by the errgroup (on a task error) and by us (when a Required() task
+	// returns, even without an error).
+	ctx, cancel := context.WithCancel(ctx)
+
 	grp, gCtx := errgroup.WithContext(ctx)
 
 	eg := ErrGroup{
 		logger: logger,
 		grp:    grp,
 		gCtx:   gCtx,
+		cancel: cancel,
 	}
 
 	return &eg
@@ -29,6 +36,7 @@ type ErrGroup struct {
 	logger *slog.Logger
 	grp    *errgroup.Group
 	gCtx   context.Context
+	cancel context.CancelFunc
 }
 
 func (eg *ErrGroup) Go(task string, fn func(ctx context.Context) error) {
@@ -38,6 +46,38 @@ func (eg *ErrGroup) Go(task string, fn func(ctx context.Context) error) {
 
 		defer eg.logger.Info("stopped task",
 			LogKeyName, task)
+
+		err := CallWithRecover(eg.gCtx, fn)
+		if err != nil {
+			return fmt.Errorf("%s: %w", task, err)
+		}
+
+		return nil
+	})
+}
+
+// Required runs a task that the rest of the group depends on. Unlike Go, the
+// group context is cancelled as soon as the task returns — even if it returns
+// a nil error — which stops the sibling tasks and unblocks Wait.
+//
+// Use it for subsystems that must run for the entire lifetime of the service:
+// if one exits for any reason we want the whole service to stop and be
+// restarted, rather than linger with only a subset of its subsystems running.
+// A nil return still yields a nil Wait result unless a sibling reports an
+// error, so a clean shutdown stays clean.
+func (eg *ErrGroup) Required(task string, fn func(ctx context.Context) error) {
+	eg.grp.Go(func() error {
+		eg.logger.Info("starting task",
+			LogKeyName, task)
+
+		defer eg.logger.Info("stopped task",
+			LogKeyName, task)
+
+		// The group can't continue without this task, so cancel the
+		// group context when it returns regardless of whether it
+		// failed. This stops the sibling tasks instead of leaving
+		// them running without a subsystem they depend on.
+		defer eg.cancel()
 
 		err := CallWithRecover(eg.gCtx, fn)
 		if err != nil {
@@ -111,6 +151,10 @@ func (eg *ErrGroup) GoWithRetries(
 }
 
 func (eg *ErrGroup) Wait() error {
+	// Release the context we derived in NewErrGroup once every task has
+	// returned.
+	defer eg.cancel()
+
 	return eg.grp.Wait()
 }
 

--- a/errgroup_test.go
+++ b/errgroup_test.go
@@ -56,6 +56,52 @@ func TestErrGroupRequiredCancelsOnCleanReturn(t *testing.T) {
 	}
 }
 
+// TestErrGroupRequiredDisabledDoesNotCancel verifies that a Required task
+// returning ErrTaskDisabled is treated as if it was never registered: the
+// group is not cancelled and Wait returns nil once the remaining tasks finish.
+func TestErrGroupRequiredDisabledDoesNotCancel(t *testing.T) {
+	grp := elephantine.NewErrGroup(context.Background(), discardLogger())
+
+	releaseSibling := make(chan struct{})
+
+	grp.Go("sibling", func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-releaseSibling:
+			return nil
+		}
+	})
+
+	grp.Required("disabled", func(_ context.Context) error {
+		return elephantine.ErrTaskDisabled
+	})
+
+	waitReturned := make(chan error, 1)
+	go func() {
+		waitReturned <- grp.Wait()
+	}()
+
+	// The disabled task returned, but it must not have cancelled the
+	// group: the sibling should still be running.
+	select {
+	case <-waitReturned:
+		t.Fatal("Wait returned while a sibling was still running; disabled task cancelled the group")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(releaseSibling)
+
+	select {
+	case err := <-waitReturned:
+		if err != nil {
+			t.Fatalf("expected nil error from Wait, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait did not return after sibling completed")
+	}
+}
+
 // TestErrGroupRequiredPropagatesError verifies that an error from a Required
 // task is surfaced by Wait.
 func TestErrGroupRequiredPropagatesError(t *testing.T) {

--- a/errgroup_test.go
+++ b/errgroup_test.go
@@ -1,0 +1,126 @@
+package elephantine_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/ttab/elephantine"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestErrGroupRequiredCancelsOnCleanReturn verifies that a Required task
+// returning a nil error still cancels the group context, so a long-running
+// sibling stops and Wait returns instead of blocking forever.
+func TestErrGroupRequiredCancelsOnCleanReturn(t *testing.T) {
+	grp := elephantine.NewErrGroup(context.Background(), discardLogger())
+
+	siblingStopped := make(chan struct{})
+
+	grp.Go("sibling", func(ctx context.Context) error {
+		<-ctx.Done()
+		close(siblingStopped)
+
+		return nil
+	})
+
+	grp.Required("required", func(_ context.Context) error {
+		// Exit cleanly and immediately.
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- grp.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil error from Wait, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait did not return after required task exited (zombie group)")
+	}
+
+	select {
+	case <-siblingStopped:
+	default:
+		t.Fatal("sibling was not cancelled when required task returned")
+	}
+}
+
+// TestErrGroupRequiredPropagatesError verifies that an error from a Required
+// task is surfaced by Wait.
+func TestErrGroupRequiredPropagatesError(t *testing.T) {
+	grp := elephantine.NewErrGroup(context.Background(), discardLogger())
+
+	sentinel := errors.New("boom")
+
+	grp.Go("sibling", func(ctx context.Context) error {
+		<-ctx.Done()
+
+		return nil
+	})
+
+	grp.Required("required", func(_ context.Context) error {
+		return sentinel
+	})
+
+	err := grp.Wait()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error from Wait, got: %v", err)
+	}
+}
+
+// TestErrGroupGoDoesNotCancelOnCleanReturn documents the contrast: a plain Go
+// task returning nil must NOT stop its siblings. This is the zombie behaviour
+// that Required exists to avoid.
+func TestErrGroupGoDoesNotCancelOnCleanReturn(t *testing.T) {
+	grp := elephantine.NewErrGroup(context.Background(), discardLogger())
+
+	releaseSibling := make(chan struct{})
+
+	grp.Go("sibling", func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-releaseSibling:
+			return nil
+		}
+	})
+
+	grp.Go("short", func(_ context.Context) error {
+		return nil
+	})
+
+	waitReturned := make(chan error, 1)
+	go func() {
+		waitReturned <- grp.Wait()
+	}()
+
+	// The short task has returned nil, but the sibling should still be
+	// running: Wait must not have returned yet.
+	select {
+	case <-waitReturned:
+		t.Fatal("Wait returned while a sibling was still running")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(releaseSibling)
+
+	select {
+	case err := <-waitReturned:
+		if err != nil {
+			t.Fatalf("expected nil error from Wait, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait did not return after sibling completed")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `ErrGroup.Required`, a variant of `Go` for tasks the rest of the group depends on, plus an `ErrTaskDisabled` sentinel for opting such tasks out by configuration.

### `Required`
When a `Required` task returns, the group context is cancelled regardless of whether it returned an error — so sibling tasks stop and `Wait` unblocks.

This is for subsystems that must run for the entire lifetime of a service. With plain `Go`, a task returning `nil` neither cancels the group nor unblocks `Wait` (which keeps waiting on the other tasks), so a subsystem that quietly stops leaves the service running as a zombie — up and serving, but no longer doing the work it exists for. `Required` makes such an exit bring the whole service down so it can be restarted.

- `NewErrGroup` now derives its own cancellable context *before* handing it to the underlying errgroup, so the group context tasks observe is cancelled both by the errgroup (on a task error) and by us (when a `Required` task returns). `Wait` releases it.
- Plain `Go` behaviour is unchanged: a `nil` return does not stop siblings.

### `ErrTaskDisabled` sentinel
Some required subsystems are disabled by configuration (e.g. an eventlog consumer skipped in one-shot/collect mode, S3 dump loading turned off, repo sync disabled). Without a way to express that, every such task has to be wrapped in a conditional at the registration site:

```go
if cfg.DumpLoading {
    grp.Required("dump collection", dumpLoop)
}
// ...repeated for every optionally-disabled subsystem
```

A `Required` task can instead return `ErrTaskDisabled` to opt out from the inside. The group then treats it as if it was never registered: it does **not** cancel the group, and `Wait` does **not** report it as an error. Callers register unconditionally and decide at runtime:

```go
grp.Required("dump collection", func(ctx context.Context) error {
    if !cfg.DumpLoading {
        return elephantine.ErrTaskDisabled
    }
    return dumpLoop(ctx)
})
```

This keeps the enable/disable decision next to the task's own logic instead of scattering `if` guards across the registration block, which matters once most of a service's tasks are `Required`.

### Tests
- `Required` nil-return cancels siblings and `Wait` returns nil.
- `Required` returning `ErrTaskDisabled` does **not** cancel the group; a running sibling keeps going and `Wait` returns nil once it finishes.
- `Required` error is propagated by `Wait`.
- Plain `Go` nil-return does not stop a running sibling (the zombie behaviour `Required` avoids).