### PR TITLE
pace job lock restarts and ping retries

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -79,8 +79,9 @@ Every service should have:
    primary pool; additional pools are named for their role (e.g.
    `"pubsub"`).
 2. **Job locks** — every `pg.NewJobLock`/`pg.RunInJobLock` call passes
-   `MetricsRegisterer` so `pg_job_lock_held` and
-   `pg_job_lock_transitions_total` land on the service registry.
+   `MetricsRegisterer` so `pg_job_lock_held`,
+   `pg_job_lock_transitions_total`, and `pg_job_lock_restarts_total` land
+   on the service registry.
 3. **Outbound HTTP** — one `elephantine.NewHTTPClientIntrumentation` per
    binary, and every outbound client instrumented under its own name
    (`repository`, `assets`, `s3`, `oidc`, `jwks`, ...), one name per
@@ -92,6 +93,17 @@ Every service should have:
 5. **Task groups** — top-level subsystems run under
    `elephantine.NewErrGroup` so panics are recovered and restarts are
    counted in `task_restarts_total`.
+
+## Job lock alerting
+
+`pg_job_lock_restarts_total{name}` counts restarts of a
+`pg.RunInJobLock`-supervised function after an error return. Restart
+pacing keeps a failing worker from hammering the shared database, but it
+does not make the worker healthy — alert on a sustained non-zero
+`rate(pg_job_lock_restarts_total[5m])`.
+`rate(pg_job_lock_transitions_total[5m])` is the indirect signal for the
+same condition (lock churn) and additionally catches a lock ping-ponging
+between replicas.
 
 ## Enforcement
 

--- a/pg/export_test.go
+++ b/pg/export_test.go
@@ -1,0 +1,13 @@
+package pg
+
+import "time"
+
+// Exported for testing.
+type RestartPacer = restartPacer
+
+// Exported for testing.
+const (
+	RestartMinRuntime   time.Duration = restartMinRuntime
+	RestartBackoffFloor time.Duration = restartBackoffFloor
+	RestartBackoffCeil  time.Duration = restartBackoffCeil
+)

--- a/pg/joblock.go
+++ b/pg/joblock.go
@@ -210,6 +210,10 @@ func (jl *JobLock) run() {
 // RunWithContext runs the provided function once the job lock has been
 // acquired. The context provided to the function will be cancelled if the job
 // lock is lost.
+//
+// The function is run at most once: when it returns the lock is released,
+// and the JobLock cannot be reused. Use RunInJobLock for supervised
+// restarts.
 func (jl *JobLock) RunWithContext(
 	ctx context.Context,
 	fn func(ctx context.Context) error,

--- a/pg/joblock.go
+++ b/pg/joblock.go
@@ -60,6 +60,7 @@ type JobLock struct {
 	db            *pgxpool.Pool
 	state         JobLockState
 	lastPing      time.Time
+	lastAttempt   time.Time
 	out           chan JobLockState
 	abort         chan struct{}
 	cleanedUp     chan struct{}
@@ -308,7 +309,7 @@ func (jl *JobLock) loop() {
 		case JobLockStateLost:
 			return
 		case JobLockStateHeld:
-			wait = time.After(time.Until(jl.lastPing.Add(jl.pingInterval)))
+			wait = time.After(jl.nextPingWait())
 		default:
 			wait = time.After(jl.checkInterval)
 		}
@@ -459,7 +460,24 @@ func (jl *JobLock) release() {
 	}
 }
 
+// nextPingWait returns how long to wait before the next ping attempt. Pings
+// are paced from the last attempt, not the last success: lastPing only
+// advances on successful pings, since staleness is measured from it, so a
+// wait computed from lastPing alone goes negative as soon as a ping fails
+// and turns the retries into a busy-loop for the rest of the stale window.
+func (jl *JobLock) nextPingWait() time.Duration {
+	since := jl.lastPing
+
+	if jl.lastAttempt.After(since) {
+		since = jl.lastAttempt
+	}
+
+	return time.Until(since.Add(jl.pingInterval))
+}
+
 func (jl *JobLock) ping() JobLockState {
+	jl.lastAttempt = time.Now()
+
 	ctx, cancel := context.WithTimeout(context.Background(), jl.timeout)
 	defer cancel()
 

--- a/pg/joblock_internal_test.go
+++ b/pg/joblock_internal_test.go
@@ -1,0 +1,46 @@
+package pg
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNextPingWaitPacesFailedPings verifies that ping retries are paced from
+// the last attempt rather than the last successful ping. lastPing is frozen
+// while pings fail, so a wait computed from it goes negative and busy-loops.
+func TestNextPingWaitPacesFailedPings(t *testing.T) {
+	interval := 10 * time.Second
+
+	jl := JobLock{
+		pingInterval: interval,
+		// Last successful ping long overdue, as during a database
+		// outage.
+		lastPing: time.Now().Add(-3 * interval),
+		// A ping attempt just failed.
+		lastAttempt: time.Now(),
+	}
+
+	wait := jl.nextPingWait()
+
+	if wait < interval-time.Second || wait > interval {
+		t.Fatalf("expected wait close to %s after a failed ping, got %s",
+			interval, wait)
+	}
+}
+
+// TestNextPingWaitHealthy verifies the normal cadence: with a fresh
+// successful ping the next one is due a ping interval later.
+func TestNextPingWaitHealthy(t *testing.T) {
+	interval := 10 * time.Second
+
+	jl := JobLock{
+		pingInterval: interval,
+		lastPing:     time.Now(),
+	}
+
+	wait := jl.nextPingWait()
+
+	if wait < interval-time.Second || wait > interval {
+		t.Fatalf("expected wait close to %s, got %s", interval, wait)
+	}
+}

--- a/pg/joblock_service.go
+++ b/pg/joblock_service.go
@@ -4,13 +4,68 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/ttab/elephantine"
 )
 
-// RunInJobLock will attempt to acquire a job lock and run the provided function
-// until the context is cancelled.
+const (
+	// restartMinRuntime is the minimum time between two starts of the
+	// function run by RunInJobLock. A run that returns faster than this is
+	// padded out to it before the lock is re-acquired, and a run that
+	// lasts at least this long is considered healthy and resets the error
+	// backoff.
+	restartMinRuntime = 10 * time.Second
+	// restartBackoffFloor and restartBackoffCeil bound the exponential
+	// backoff applied when the function returns an error.
+	restartBackoffFloor = 1 * time.Second
+	restartBackoffCeil  = 60 * time.Second
+)
+
+// restartPacer decides how long RunInJobLock should wait before restarting
+// the guarded function.
+type restartPacer struct {
+	backoff time.Duration
+}
+
+// Pace returns the delay before the next restart given how long the previous
+// run lasted and the error it returned. Errors are subject to exponential
+// backoff with jitter, and all returns are padded so that runs start at most
+// once per restartMinRuntime.
+func (p *restartPacer) Pace(runtime time.Duration, err error) time.Duration {
+	if p.backoff == 0 || runtime >= restartMinRuntime {
+		p.backoff = restartBackoffFloor
+	}
+
+	var delay time.Duration
+
+	if err != nil {
+		// Equal jitter: delay in [backoff/2, backoff).
+		//nolint:gosec // G404: jitter is not security sensitive.
+		delay = p.backoff/2 + rand.N(p.backoff/2)
+
+		p.backoff = min(2*p.backoff, restartBackoffCeil)
+	}
+
+	return max(delay, restartMinRuntime-runtime)
+}
+
+// RunInJobLock runs fn under the named job lock, restarting it until the
+// context is cancelled.
+//
+// The function is expected to block until its context is cancelled: the
+// context it receives is tied to the held lock, and returning — with or
+// without an error — releases the lock, after which RunInJobLock re-acquires
+// it and starts the function again. This is not a way to run something
+// exactly once.
+//
+// Restarts are paced: an error return is retried with exponential backoff
+// (capped at a minute, reset after a healthy run), and any return is padded
+// so that the function starts at most once every ten seconds. While waiting
+// the lock stays released, so another instance can take over.
 func RunInJobLock(
 	ctx context.Context,
 	db *pgxpool.Pool,
@@ -20,25 +75,60 @@ func RunInJobLock(
 	options JobLockOptions,
 	fn func(ctx context.Context) error,
 ) error {
+	reg := options.MetricsRegisterer
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+
+	restartsVec, err := elephantine.RegisterOrReuse(reg,
+		prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "pg_job_lock_restarts_total",
+			Help: "Restarts of a job lock guarded function after " +
+				"an error return. A sustained rate means the " +
+				"job is failing persistently and only being " +
+				"kept alive by restart backoff.",
+		}, []string{jobLockNameLabel}))
+	if err != nil {
+		return fmt.Errorf("register job lock restarts metric: %w", err)
+	}
+
+	restarts := restartsVec.WithLabelValues(lockName)
+
+	var pacer restartPacer
+
 	for {
 		lock, err := NewJobLock(db, logger, lockName, options)
 		if err != nil {
 			return fmt.Errorf("create job lock: %w", err)
 		}
 
-		err = lock.RunWithContext(ctx, func(ctx context.Context) error {
-			return fn(ctx)
-		})
+		started := time.Now()
+
+		err = lock.RunWithContext(ctx, fn)
 		if err != nil {
+			restarts.Inc()
+
 			logger.ErrorContext(ctx,
 				fmt.Sprintf("failed to run %s in job lock", serviceName),
 				elephantine.LogKeyError, err)
 		}
 
+		wait := pacer.Pace(time.Since(started), err)
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
+		}
+
+		timer := time.NewTimer(wait)
+
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+
+			return ctx.Err()
+		case <-timer.C:
 		}
 	}
 }

--- a/pg/joblock_service_test.go
+++ b/pg/joblock_service_test.go
@@ -1,0 +1,90 @@
+package pg_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ttab/elephantine/pg"
+)
+
+func TestRestartPacerPadsFastReturns(t *testing.T) {
+	var p pg.RestartPacer
+
+	// A fast nil return is padded out to the minimum runtime.
+	wait := p.Pace(time.Millisecond, nil)
+
+	lower := pg.RestartMinRuntime - 10*time.Millisecond
+
+	if wait < lower || wait > pg.RestartMinRuntime {
+		t.Fatalf("expected wait close to %s, got %s",
+			pg.RestartMinRuntime, wait)
+	}
+
+	// A healthy long run is restarted immediately.
+	wait = p.Pace(pg.RestartMinRuntime+time.Second, nil)
+	if wait != 0 {
+		t.Fatalf("expected no wait after a long run, got %s", wait)
+	}
+}
+
+func TestRestartPacerBacksOffOnErrors(t *testing.T) {
+	var p pg.RestartPacer
+
+	errFail := errors.New("dependency down")
+
+	// The minimum runtime pad dominates until the backoff exceeds it,
+	// then the backoff takes over and caps at the ceiling.
+	var previous time.Duration
+
+	for i := range 10 {
+		wait := p.Pace(time.Millisecond, errFail)
+
+		if wait < previous/2 {
+			t.Fatalf("iteration %d: wait %s dropped below half of previous %s",
+				i, wait, previous)
+		}
+
+		if wait > pg.RestartBackoffCeil {
+			t.Fatalf("iteration %d: wait %s exceeds the cap %s",
+				i, wait, pg.RestartBackoffCeil)
+		}
+
+		previous = wait
+	}
+
+	// After ten consecutive fast failures the backoff must have grown
+	// past the minimum runtime pad.
+	if previous <= pg.RestartMinRuntime {
+		t.Fatalf("expected backoff to exceed %s after repeated failures, got %s",
+			pg.RestartMinRuntime, previous)
+	}
+
+	// A healthy run resets the backoff to the floor.
+	wait := p.Pace(pg.RestartMinRuntime+time.Second, errFail)
+	if wait < pg.RestartBackoffFloor/2 || wait >= pg.RestartBackoffFloor {
+		t.Fatalf("expected wait in [%s, %s) after reset, got %s",
+			pg.RestartBackoffFloor/2, pg.RestartBackoffFloor, wait)
+	}
+}
+
+func TestRestartPacerJitterBounds(t *testing.T) {
+	errFail := errors.New("dependency down")
+
+	// Drive the backoff to the ceiling, then check that jittered delays
+	// stay within [ceil/2, ceil).
+	var p pg.RestartPacer
+
+	for range 10 {
+		p.Pace(time.Millisecond, errFail)
+	}
+
+	for range 100 {
+		wait := p.Pace(time.Millisecond, errFail)
+
+		if wait < pg.RestartBackoffCeil/2 || wait >= pg.RestartBackoffCeil {
+			t.Fatalf("expected wait in [%s, %s), got %s",
+				pg.RestartBackoffCeil/2, pg.RestartBackoffCeil, wait)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`pg.RunInJobLock` restarted `fn` with zero delay whenever it returned, error or nil: the instance had just released its own lock row, so re-acquisition succeeded instantly. A worker whose downstream dependency fails fast (OpenSearch down, poison input) turned into a tight loop of lock delete/insert churn against the shared database, an error log line per iteration, and thousands of `pg_job_lock_transitions_total` transitions — while doing no useful work. The doc comment never stated that returning restarts immediately, so call sites discovered it the hard way and either relied on it accidentally or built private supervision around it.

Restarts are now paced:

* Error returns from `fn` get exponential backoff with equal jitter, 1 s floor, 60 s cap.
* Every return — error or nil — is padded so `fn` starts at most once every ten seconds, which also covers the nil-return spin.
* A run lasting at least the minimum runtime counts as healthy and resets the backoff.
* The wait is context-cancellable, and the lock stays released during it so another replica (possibly one with a working network path to the failing dependency) can take over.

A new `pg_job_lock_restarts_total{name}` counter is incremented when `fn` returns an error — the direct signal that a job is failing persistently and only being kept alive by restart backoff. `docs/metrics.md` gets a job lock alerting section recommending an alert on its sustained rate.

The contract is now documented: `fn` is expected to block until its context is cancelled; `RunInJobLock` is not a run-once mechanism, and `JobLock.RunWithContext` is explicitly one-shot.

Relatedly, a failed ping left `lastPing` untouched while the held-state wait was computed from it, so an instantly failing connection (e.g. a dead primary IP after a database failover) produced hundreds of ping attempts and error log lines per second for the whole stale window. Ping retries are now paced from the last attempt, keeping `lastPing` as the staleness anchor.

Existing callers that block forever are unaffected; callers that returned errors expecting a restart now recover marginally slower from transient failures (bounded by the backoff floor) but no longer hammer the shared database during persistent ones. No signature changes.